### PR TITLE
Technical/Refactor validate entrypoint DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,14 @@ configuration := truemail.NewConfiguration(
   },
 )
 ```
+
+#### Using configuration
+
+```go
+import "github.com/truemail-rb/truemail-go"
+
+configuration := truemail.NewConfiguration(ConfigurationAttr{verifierEmail: "verifier@example.com"})
+
+truemail.Validate("some@email.com", configuration)
+truemail.isValid("some@email.com", configuration, "regex")
+```

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -26,11 +26,9 @@ func createConfiguration() *configuration {
 	return configuration
 }
 
-func createValidatorResult(email string, configuration *configuration, validationType ...string) *validatorResult {
-	if len(validationType) == 0 {
-		validationType = append(validationType, ValidationTypeDefault)
-	}
-	validatorResult := &validatorResult{Email: email, Configuration: configuration, ValidationType: validationType[0]}
+func createValidatorResult(email string, configuration *configuration, options ...string) *validatorResult {
+	validationType, _ := variadicValidationType(options)
+	validatorResult := &validatorResult{Email: email, Configuration: configuration, ValidationType: validationType}
 	validatorResult.validator = &validator{result: validatorResult}
 	return validatorResult
 }

--- a/validator.go
+++ b/validator.go
@@ -2,25 +2,14 @@ package truemail
 
 import "fmt"
 
-func Validate(validationAttr ValidationAttr) (*validatorResult, error) {
-	validationType, validationConfiguration := validationAttr.validationType, validationAttr.configuration
+func Validate(email string, configuration *configuration, options ...string) (*validatorResult, error) {
+	validationType, err := variadicValidationType(options)
 
-	if validationType == "" {
-		validationType = ValidationTypeDefault
-	}
-
-	err := validateValidationTypeContext(validationType)
 	if err != nil {
 		return nil, err
 	}
 
-	return newValidator(validationAttr.email, validationType, validationConfiguration).run(), err
-}
-
-// ValidationAttr kwargs for validator enrty point
-type ValidationAttr struct {
-	email, validationType string
-	configuration         *configuration
+	return newValidator(email, validationType, configuration).run(), err
 }
 
 // validatorResult structure
@@ -38,6 +27,15 @@ type validator struct {
 	result                    *validatorResult
 	usedValidations           []string
 	isPassFromDomainListMatch bool
+}
+
+func variadicValidationType(options []string) (string, error) {
+	if len(options) == 0 {
+		return ValidationTypeDefault, nil
+	}
+
+	validationType := options[0]
+	return validationType, validateValidationTypeContext(validationType)
 }
 
 func validateValidationTypeContext(validationType string) error {


### PR DESCRIPTION
Ability to use more clear syntax instead of params from structure:

```go
truemail.Validate("some@email.com", configuration)
truemail.isValid("some@email.com", configuration, "regex")
```

- [x] Refactored `.Validate()` DSL
- [x] Refactored test helpers