### PR TITLE
Technical/Move validatorResult.Domain assign to validationDomainListMatch

### DIFF
--- a/domain_list_match.go
+++ b/domain_list_match.go
@@ -5,6 +5,8 @@ type validationDomainListMatch struct{}
 
 // interface implementation
 func (validation *validationDomainListMatch) check(validatorResult *validatorResult) *validatorResult {
+	validatorResult.setDomain()
+
 	// Failure scenario
 	if validation.isBlacklistedDomain(validatorResult) ||
 		(validation.isWhitelistValidation(validatorResult) && !validation.isWhitelistedDomain(validatorResult)) {
@@ -35,10 +37,7 @@ func (validation *validationDomainListMatch) check(validatorResult *validatorRes
 
 // Returns true if email domain is included in whitelisted domains slice, otherwise returns false
 func (validation *validationDomainListMatch) isWhitelistedDomain(validatorResult *validatorResult) bool {
-	return isIncluded(
-		validatorResult.Configuration.WhitelistedDomains,
-		emailDomain(validatorResult.Email),
-	)
+	return isIncluded(validatorResult.Configuration.WhitelistedDomains, validatorResult.Domain)
 }
 
 // Returns true if whitelist validation enebled, otherwise returns false
@@ -48,8 +47,5 @@ func (validation *validationDomainListMatch) isWhitelistValidation(validatorResu
 
 // Returns true if email domain is included in blacklisted domains slice, otherwise returns false
 func (validation *validationDomainListMatch) isBlacklistedDomain(validatorResult *validatorResult) bool {
-	return isIncluded(
-		validatorResult.Configuration.BlacklistedDomains,
-		emailDomain(validatorResult.Email),
-	)
+	return isIncluded(validatorResult.Configuration.BlacklistedDomains, validatorResult.Domain)
 }

--- a/domain_list_match_test.go
+++ b/domain_list_match_test.go
@@ -21,6 +21,7 @@ func TestValidationDomainListMatchCheck(t *testing.T) {
 		assert.True(t, validatorResult.Success)
 		assert.False(t, validatorResult.isPassFromDomainListMatch)
 		assert.Equal(t, DomainListMatchWhitelist, validatorResult.ValidationType)
+		assert.Equal(t, domain, validatorResult.Domain)
 	})
 
 	t.Run("blacklist case, email is in blacklist", func(t *testing.T) {
@@ -35,6 +36,7 @@ func TestValidationDomainListMatchCheck(t *testing.T) {
 		assert.False(t, validatorResult.Success)
 		assert.False(t, validatorResult.isPassFromDomainListMatch)
 		assert.Equal(t, DomainListMatchBlacklist, validatorResult.ValidationType)
+		assert.Equal(t, domain, validatorResult.Domain)
 	})
 
 	t.Run("whitelist/blackist case, email is not in both lists", func(t *testing.T) {
@@ -49,6 +51,7 @@ func TestValidationDomainListMatchCheck(t *testing.T) {
 		assert.True(t, validatorResult.Success)
 		assert.True(t, validatorResult.isPassFromDomainListMatch)
 		assert.Equal(t, validationType, validatorResult.ValidationType)
+		assert.Equal(t, domain, validatorResult.Domain)
 	})
 
 	t.Run("whitelist/blackist case, email is in both lists", func(t *testing.T) {
@@ -64,6 +67,7 @@ func TestValidationDomainListMatchCheck(t *testing.T) {
 		assert.False(t, validatorResult.Success)
 		assert.False(t, validatorResult.isPassFromDomainListMatch)
 		assert.Equal(t, DomainListMatchBlacklist, validatorResult.ValidationType)
+		assert.Equal(t, domain, validatorResult.Domain)
 	})
 
 	t.Run("whitelist validation case, email is in whitelist", func(t *testing.T) {
@@ -80,6 +84,7 @@ func TestValidationDomainListMatchCheck(t *testing.T) {
 		assert.True(t, validatorResult.Success)
 		assert.True(t, validatorResult.isPassFromDomainListMatch)
 		assert.Equal(t, validationType, validatorResult.ValidationType)
+		assert.Equal(t, domain, validatorResult.Domain)
 	})
 
 	t.Run("whitelist validation case, email is not in whitelist/blacklist", func(t *testing.T) {
@@ -94,6 +99,7 @@ func TestValidationDomainListMatchCheck(t *testing.T) {
 		assert.False(t, validatorResult.Success)
 		assert.False(t, validatorResult.isPassFromDomainListMatch)
 		assert.Equal(t, DomainListMatchBlacklist, validatorResult.ValidationType)
+		assert.Equal(t, domain, validatorResult.Domain)
 	})
 
 	t.Run("whitelist validation case, email is in blacklist", func(t *testing.T) {
@@ -109,6 +115,7 @@ func TestValidationDomainListMatchCheck(t *testing.T) {
 		assert.False(t, validatorResult.Success)
 		assert.False(t, validatorResult.isPassFromDomainListMatch)
 		assert.Equal(t, DomainListMatchBlacklist, validatorResult.ValidationType)
+		assert.Equal(t, domain, validatorResult.Domain)
 	})
 
 	t.Run("whitelist validation case, email is in both lists", func(t *testing.T) {
@@ -125,6 +132,7 @@ func TestValidationDomainListMatchCheck(t *testing.T) {
 		assert.False(t, validatorResult.Success)
 		assert.False(t, validatorResult.isPassFromDomainListMatch)
 		assert.Equal(t, DomainListMatchBlacklist, validatorResult.ValidationType)
+		assert.Equal(t, domain, validatorResult.Domain)
 	})
 }
 
@@ -134,6 +142,7 @@ func TestValidationDomainListMatchIsWhitelistedDomain(t *testing.T) {
 	t.Run("when whitelisted domain", func(t *testing.T) {
 		configuration, _ := NewConfiguration(ConfigurationAttr{verifierEmail: randomEmail(), whitelistedDomains: []string{domain}})
 		validatorResult := createValidatorResult(email, configuration)
+		validatorResult.setDomain()
 
 		assert.True(t, new(validationDomainListMatch).isWhitelistedDomain(validatorResult))
 	})
@@ -167,6 +176,7 @@ func TestValidationDomainListMatchIsBlacklistedDomain(t *testing.T) {
 	t.Run("when blacklisted domain", func(t *testing.T) {
 		configuration, _ := NewConfiguration(ConfigurationAttr{verifierEmail: randomEmail(), blacklistedDomains: []string{domain}})
 		validatorResult := createValidatorResult(email, configuration)
+		validatorResult.setDomain()
 
 		assert.True(t, new(validationDomainListMatch).isBlacklistedDomain(validatorResult))
 	})

--- a/mx.go
+++ b/mx.go
@@ -23,7 +23,6 @@ type validationMx struct {
 // interface implementation
 func (validation *validationMx) check(validatorResult *validatorResult) *validatorResult {
 	validation.result = validatorResult
-	validation.setValidatorResultDomain()
 	validation.setValidatorResultPunycodeRepresentation()
 	validation.initDnsResolver()
 	validation.runMxLookup()
@@ -37,11 +36,6 @@ func (validation *validationMx) check(validatorResult *validatorResult) *validat
 }
 
 // validationMx methods
-
-// Assigns domain from validated email to validatorResult
-func (validation *validationMx) setValidatorResultDomain() {
-	validation.result.Domain = emailDomain(validation.result.Email)
-}
 
 // Returns punycode domain representation
 func (validation *validationMx) punycodeDomain(domain string) string {

--- a/mx_test.go
+++ b/mx_test.go
@@ -43,7 +43,6 @@ func TestValidationMxCheck(t *testing.T) {
 		assert.True(t, validatorResult.Success)
 		assert.Empty(t, validatorResult.Errors)
 		assert.Empty(t, validatorResult.usedValidations)
-		assert.Equal(t, targetHostName, validatorResult.Domain)
 		assert.Equal(t, punycodeDomain(targetHostName), validatorResult.punycodeDomain)
 		assert.Equal(t, targetUserName+punycodeDomain(targetHostName), validatorResult.punycodeEmail)
 		assert.Equal(t, []string{resolvedIpAddressFirst, resolvedIpAddressSecond}, validatorResult.MailServers)
@@ -91,7 +90,6 @@ func TestValidationMxCheck(t *testing.T) {
 		assert.True(t, validatorResult.Success)
 		assert.Empty(t, validatorResult.Errors)
 		assert.Empty(t, validatorResult.usedValidations)
-		assert.Equal(t, targetHostName, validatorResult.Domain)
 		assert.Equal(t, punycodeDomain(targetHostName), validatorResult.punycodeDomain)
 		assert.Equal(t, targetUserName+punycodeDomain(targetHostName), validatorResult.punycodeEmail)
 		assert.Equal(t, []string{resolvedIpAddressSecond, resolvedIpAddressFirst}, validatorResult.MailServers)
@@ -111,7 +109,6 @@ func TestValidationMxCheck(t *testing.T) {
 		assert.True(t, validatorResult.Success)
 		assert.Empty(t, validatorResult.Errors)
 		assert.Empty(t, validatorResult.usedValidations)
-		assert.Equal(t, targetHostName, validatorResult.Domain)
 		assert.Equal(t, punycodeDomain(targetHostName), validatorResult.punycodeDomain)
 		assert.Equal(t, targetUserName+punycodeDomain(targetHostName), validatorResult.punycodeEmail)
 		assert.Equal(t, []string{resolvedIpAddressFirst}, validatorResult.MailServers)
@@ -125,7 +122,6 @@ func TestValidationMxCheck(t *testing.T) {
 		assert.False(t, validatorResult.Success)
 		assert.Equal(t, map[string]string{"mx": MxErrorContext}, validatorResult.Errors)
 		assert.Empty(t, validatorResult.usedValidations)
-		assert.Equal(t, targetHostName, validatorResult.Domain)
 		assert.Equal(t, punycodeDomain(targetHostName), validatorResult.punycodeDomain)
 		assert.Equal(t, targetUserName+punycodeDomain(targetHostName), validatorResult.punycodeEmail)
 		assert.Empty(t, validatorResult.MailServers)
@@ -147,7 +143,6 @@ func TestValidationMxCheck(t *testing.T) {
 		assert.False(t, validatorResult.Success)
 		assert.Equal(t, map[string]string{"mx": MxErrorContext}, validatorResult.Errors)
 		assert.Empty(t, validatorResult.usedValidations)
-		assert.Equal(t, targetHostName, validatorResult.Domain)
 		assert.Equal(t, punycodeDomain(targetHostName), validatorResult.punycodeDomain)
 		assert.Equal(t, targetUserName+punycodeDomain(targetHostName), validatorResult.punycodeEmail)
 		assert.Empty(t, validatorResult.MailServers)
@@ -166,21 +161,9 @@ func TestValidationMxCheck(t *testing.T) {
 		assert.False(t, validatorResult.Success)
 		assert.Equal(t, map[string]string{"mx": MxErrorContext}, validatorResult.Errors)
 		assert.Empty(t, validatorResult.usedValidations)
-		assert.Equal(t, targetHostName, validatorResult.Domain)
 		assert.Equal(t, punycodeDomain(targetHostName), validatorResult.punycodeDomain)
 		assert.Equal(t, targetUserName+punycodeDomain(targetHostName), validatorResult.punycodeEmail)
 		assert.Empty(t, validatorResult.MailServers)
-	})
-}
-
-func TestValidationMxSetValidatorResultDomain(t *testing.T) {
-	t.Run("sets domain to validatorResult", func(t *testing.T) {
-		email, domain := pairRandomEmailDomain()
-		validatorResult := &validatorResult{Email: email + "@" + domain}
-		validation := &validationMx{result: validatorResult}
-		validation.setValidatorResultDomain()
-
-		assert.Equal(t, validatorResult.Domain, domain)
 	})
 }
 

--- a/test_helpers.go
+++ b/test_helpers.go
@@ -89,7 +89,7 @@ func createValidatorResult(email string, configuration *configuration, options .
 }
 
 func createSuccessfulValidatorResult(email string, configuration *configuration) *validatorResult {
-	return &validatorResult{Email: email, Configuration: copyConfigurationByPointer(configuration), Success: true}
+	return &validatorResult{Email: email, Domain: emailDomain(email), Configuration: copyConfigurationByPointer(configuration), Success: true}
 }
 
 func randomValidationType() string {

--- a/validator.go
+++ b/validator.go
@@ -25,6 +25,11 @@ func (validatorResult *validatorResult) addError(key, value string) {
 	validatorResult.Errors[key] = value
 }
 
+// Assigns domain based on validator result email to self
+func (validatorResult *validatorResult) setDomain() {
+	validatorResult.Domain = emailDomain(validatorResult.Email)
+}
+
 // Structure with behaviour. Responsible for the
 // logic of calling the validation layers sequence
 type validator struct {

--- a/validator_test.go
+++ b/validator_test.go
@@ -428,12 +428,22 @@ func TestValidatorResultAddUsedValidationType(t *testing.T) {
 	})
 }
 
-func TestValidatorAddError(t *testing.T) {
+func TestValidatorResultAddError(t *testing.T) {
 	t.Run("validatorResult#addError", func(t *testing.T) {
 		key, value := "some_error_key", "some_error_value"
 		result := new(validatorResult)
 		result.addError(key, value)
 
 		assert.Equal(t, value, result.Errors[key])
+	})
+}
+
+func TestValidatorResultSetDomain(t *testing.T) {
+	t.Run("validatorResult#setDomain", func(t *testing.T) {
+		email, domain := pairRandomEmailDomain()
+		result := &validatorResult{Email: email}
+		result.setDomain()
+
+		assert.Equal(t, domain, result.Domain)
 	})
 }


### PR DESCRIPTION
- [x] Updated `validationDomainListMatch#check`, tests
- [x] Updated `validationMx#check`, tests
- [x] Added `validatorResult#setDomain`, tests
- [x] Updated `createSuccessfulValidatorResult` test helper