### PR TITLE
Bugfix/SMTP client nil dereference

### DIFF
--- a/smtp_client.go
+++ b/smtp_client.go
@@ -102,7 +102,13 @@ func (smtpClient *smtpClient) runSession() bool {
 		smtpClient.err = &SmtpClientError{isResponseTimeout: true, err: err}
 	}
 
-	client, _ := smtp.NewClient(connection, smtpClient.targetServerAddress)
+	client, err := smtp.NewClient(connection, smtpClient.targetServerAddress)
+	// Handle connection to MX failed
+	if err != nil {
+		closeConnection()
+		return false
+	}
+
 	smtpClient.client = client
 	defer client.Close()
 


### PR DESCRIPTION
* Added error handler when opening new SMTP Client

# PR Details

<!-- Provide a general summary of your changes in the Title above -->
<!-- PR name should the same name as your branch name, example: -->
<!-- Branch name is: feature/add-some-feature -->
<!-- PR name should be: Feature/Add some feature -->
Fix bug when validate into MX server that instantly reject the connection.

## Description

<!--- Describe your changes in detail -->
Before, error in the SMTP client creation in the smtp_client.go / smtpClient.runSession are not handled like below:
```go
client, _ := smtp.NewClient(connection, smtpClient.targetServerAddress)
```

That behavior resulting runtime error in program execution, specifically nil pointer dereference. Below are the errors when it happen:
```
panic: runtime error: invalid memory address or nil pointer dereference
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x100a2bda8]

goroutine 1 [running]:
net/smtp.(*Client).Close(0x140000021a0?)
	/usr/local/go/src/net/smtp/smtp.go:78 +0x18
panic({0x100b618e0?, 0x100d7de20?})
	/usr/local/go/src/runtime/panic.go:920 +0x26c
net/smtp.(*Client).Hello(0x0, {0x100ab6293, 0xe})
	/usr/local/go/src/net/smtp/smtp.go:102 +0x38
github.com/truemail-rb/truemail-go.(*smtpClient).runSession(0x1400042f580)
	/Users/richisetyamaulana/go/pkg/mod/github.com/truemail-rb/truemail-go@v1.1.2/smtp_client.go:110 +0x1fc
github.com/truemail-rb/truemail-go.(*validationSmtp).runSmtpSession(0x14000113c20, {0x1400042a0f0?, 0x40?})
	/Users/richisetyamaulana/go/pkg/mod/github.com/truemail-rb/truemail-go@v1.1.2/smtp.go:65 +0x170
github.com/truemail-rb/truemail-go.(*validationSmtp).run(0x14000113c20)
	/Users/richisetyamaulana/go/pkg/mod/github.com/truemail-rb/truemail-go@v1.1.2/smtp.go:42 +0x88
github.com/truemail-rb/truemail-go.(*validationSmtp).check(0x14000113c20, 0x140001326e0)
	/Users/richisetyamaulana/go/pkg/mod/github.com/truemail-rb/truemail-go@v1.1.2/smtp.go:14 +0x7c
github.com/truemail-rb/truemail-go.(*validator).validateSMTP(0x140003dfcb0)
	/Users/richisetyamaulana/go/pkg/mod/github.com/truemail-rb/truemail-go@v1.1.2/validator.go:145 +0x318
github.com/truemail-rb/truemail-go.(*validator).run(0x140003dfcb0)
	/Users/richisetyamaulana/go/pkg/mod/github.com/truemail-rb/truemail-go@v1.1.2/validator.go:171 +0xd8
github.com/truemail-rb/truemail-go.Validate({0x100ac6c81, 0x17}, 0x140001910a0, {0x0?, 0x100ab6293?, 0xe?})
	/Users/richisetyamaulana/go/pkg/mod/github.com/truemail-rb/truemail-go@v1.1.2/truemail.go:13 +0x22c
main.validate({0x100ac6c81, 0x17})
	/Users/richisetyamaulana/Excellent/dev/aktiva-email-validator/main.go:148 +0x74
main.main()
	/Users/richisetyamaulana/Excellent/dev/aktiva-email-validator/main.go:80 +0x6c
exit status 2
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/truemail-rb/truemail-go/issues/80

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
- To fix the runtime error when validating into rejected MX server

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I already try to reproduce the error by validating into MX server that instantly reject the SMTP connection using my bug fix version. The results are the error are not appearing again.

Example of MX server that instantly reject can be test using telnet like below:
```bash
$ telnet mx02.mail.icloud.com. 25
Trying 17.42.251.62...
Connected to mx02.mail.icloud.com.
Escape character is '^]'.
Connection closed by foreign host.
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the [**CONTRIBUTING** document](https://github.com/truemail-rb/truemail-go/blob/master/CONTRIBUTING.md)
- [ ] I have added tests to cover my changes
